### PR TITLE
Typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ again to re-open the window
 # Installation
 
 ### Linux (AppImage)
- - Download AppImage from the [latest release of Dipuste](https://github.com/Vinegret43/dispute/releases/latest)
+ - Download AppImage from the [latest release of Dispute](https://github.com/Vinegret43/dispute/releases/latest)
  - Open your terminal and CD into the directory where it's downloaded
  - Run `chmod +x dispute-linux.AppImage` and `./dispute-linux.AppImage --install`
  - Now Dispute is available in your app launcher. Enjoy!


### PR DESCRIPTION
Sorry for the trivial PR, but there is a typo in the README saying "Dipuste" instead of "Dispute"